### PR TITLE
Added locale support for content fields

### DIFF
--- a/src/ButterCMS/ButterCMS.php
+++ b/src/ButterCMS/ButterCMS.php
@@ -152,9 +152,10 @@ class ButterCMS
     // Content Fields
     ///////////////
 
-    public function fetchContentFields(array $keys)
+    public function fetchContentFields(array $keys, array $options = [])
     {
         $params = ['keys' => implode(',', $keys)];
+        $params = array_merge($params, $options);
         $rawContentFields = $this->request('content/', $params);
         return isset($rawContentFields['data']) ? $rawContentFields['data'] : false;
     }

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -6,6 +6,6 @@
         }
     ],
     "require": {
-        "buttercms/api-wrapper": "dev-master"
+        "buttercms/buttercms-php": "dev-master"
     }
 }

--- a/tests/composer.lock
+++ b/tests/composer.lock
@@ -4,16 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d5da3e1fd9e8d6750d9305832aeb3750",
-    "content-hash": "32a70ae574e282d12bd27a3ae4ebe101",
+    "content-hash": "4b3f49de615245a8b5ce986d78f18ded",
     "packages": [
         {
-            "name": "buttercms/api-wrapper",
+            "name": "buttercms/buttercms-php",
             "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "../",
-                "reference": "a68fefeacaab6da52b8f77ce9afce529113eb677"
+                "reference": "269d237872c89b418d63c2e4179ae31db7d73984"
             },
             "require": {
                 "guzzlehttp/guzzle": "~6.0",
@@ -27,30 +26,30 @@
             },
             "authors": [
                 {
-                    "name": "Josh Holat",
-                    "email": "jholat@gmail.com"
+                    "name": "ButterCMS",
+                    "email": "support@buttercms.com"
                 }
             ],
             "description": "ButterCMS PHP API Wrapper",
-            "time": "2016-11-01 02:17:40"
+            "time": "2017-04-24 04:08:07"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.2",
+            "version": "6.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
+                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
-                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/8d6c6cc55186db87b7dc5009827429ba4e9dc006",
+                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.3.1",
+                "guzzlehttp/psr7": "^1.4",
                 "php": ">=5.5"
             },
             "require-dev": {
@@ -94,32 +93,32 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-10-08 15:01:37"
+            "time": "2017-02-28T22:50:30+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.2.0",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -145,20 +144,20 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-05-18 16:56:05"
+            "time": "2016-12-20T10:07:11+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.3.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b"
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
-                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
                 "shasum": ""
             },
             "require": {
@@ -194,16 +193,23 @@
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
                 }
             ],
-            "description": "PSR-7 message implementation",
+            "description": "PSR-7 message implementation that also provides common utility methods",
             "keywords": [
                 "http",
                 "message",
+                "request",
+                "response",
                 "stream",
-                "uri"
+                "uri",
+                "url"
             ],
-            "time": "2016-06-24 23:00:38"
+            "time": "2017-03-20T17:10:46+00:00"
         },
         {
             "name": "psr/http-message",
@@ -253,14 +259,14 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "buttercms/api-wrapper": 20
+        "buttercms/buttercms-php": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/tests/main.php
+++ b/tests/main.php
@@ -4,10 +4,10 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use ButterCMS\ButterCMS;
 
-$butterCms = new ButterCMS('fe7098cde166d497fbac00bc5d1b94cc8ce51d0f');
+$butterCms = new ButterCMS('10de91e331dd67ae3e4ee5c383ec8ea8a9427f48');
 
 // Feeds - returns a SimpleXMLElement object
-$feed = $butterCms->getFeed('rss');
+$feed = $butterCms->fetchFeed('rss');
 
 // Posts
 $response = $butterCms->fetchPost('test-post');
@@ -18,12 +18,14 @@ $butterCms->fetchPosts(['page' => 1]);
 $butterCms->searchPosts('query', ['page' => 1]);
 
 // Authors
-$butterCms->fetchAuthor('author-slug');
+$butterCms->fetchAuthor('api-test');
 $butterCms->fetchAuthors(['include' => 'recent_posts']);
 
 // Categories
-$butterCms->fetchCategory('category-slug');
+$butterCms->fetchCategory('test-category');
 $butterCms->fetchCategories(['include' => 'recent_posts']);
 
 // Content Fields - returns your fields turned in to a multidimensional array
-$butterCms->fetchContentFields(['headline', 'FAQ']);
+$fields = $butterCms->fetchContentFields(['homepage_headline', 'faq'], ['locale' => 'es']);
+
+var_dump($fields);


### PR DESCRIPTION
The `fetchContentFields` method on the `ButterCMS` class now has an optional second parameter called `$options`. It expects an associative array with key-value pairs that will be added to the URL query string on the API request. This can be used to select a locale, i.e.:

```php
$butterCms = new ButterCMS(<your_api_key>);
$fields = $butterCms->fetchContentFields(['homepage_headline', 'faq'], ['locale' => 'es']);
```