### PR TITLE
Add support for Write API operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ If you do not wish to use Composer, you can download the [latest release](https:
 require_once('/path/to/buttercms-php/src/ButterCMS.php');
 ```
 
+## Authentication
+
+By default the ButterCMS client expects a valid authentication token for all READ operations. For instructions on how to obtain a valid READ authentication token see the [API documentation](https://buttercms.com/docs/api/#authentication).
+
+Optionally, the ButterCMS client accepts a valid authentication token for all WRITE operations. . For instructions on how to obtain a valid WRITE authentication token see the [API documentation](https://buttercms.com/docs/api/#write-authentication).
+
+```php
+use ButterCMS\ButterCMS;
+
+$butterCms = new ButterCMS(
+    '<auth_token>',
+    '<write_auth_token>'    // Optional
+);
+```
+
 ## Pages
 
 For a list of `params` see the [API documentation](https://buttercms.com/docs/api/?php#pages)
@@ -35,9 +50,18 @@ For a list of `params` see the [API documentation](https://buttercms.com/docs/ap
 ```php
 use ButterCMS\ButterCMS;
 
-$butterCms = new ButterCMS('<auth_token>');
+$butterCms = new ButterCMS('<auth_token>', '<write_auth_token>');
 
+// Create a Page
+$writeApiStatus = $butterCms->createPage($params);
+
+// Fetch a Page
 $page = $butterCms->fetchPage('about', 'welcome-to-the-site');
+
+// Update a Page
+$pageData = json_decode(json_encode($page), true);
+$pageData['title'] = 'New Page Title';
+$writeApiStatus = $butterCms->updatePage('welcome-to-the-site', $pageData);
 
 // These are equivalent
 echo $page->getFields()['some-field'];
@@ -62,13 +86,44 @@ try {
 
 ## Collections
 
-For a list of `params` see the [API documentation](https://buttercms.com/docs/api/?php#retrieve-a-collection)
+For a list of `params` and functionality see the [API documentation](https://buttercms.com/docs/api/#collections)
 
 ```php
 use ButterCMS\ButterCMS;
 
-$butterCms = new ButterCMS('<auth_token>');
-$butterCms->fetchContentFields(['collection_key'], ['locale' => 'en'])
+$butterCms = new ButterCMS('<auth_token>', '<write_auth_token>');
+
+$writeApiStatus = $butterCms->createCollectionItem('collection_key', [
+    'status' => 'published',
+    'fields' => [
+        [
+          'field1_key': 'Field value',
+          'field2_key': 'Field value',
+        ]
+    ]
+]);
+
+// Get list of specific collections
+$collectionsResponse = $butterCms->fetchCollections(['collection_key'], ['locale' => 'en']);
+
+// Get a collection from the list
+$collection = $collectionsResponse->getCollection('collection_key');
+
+// Get collection items
+$items = $collection->getItems();
+
+// Update a specific item
+$item = $items[0];
+$itemData = json_decode(json_encode($item), true);
+$itemData['fields']['field1_key'] = 'New field value';
+$writeApiStatus = $butterCms->updateCollectionItem($collection->getKey(), $item->getId(), $itemData);
+
+// Delete a specific item
+$deleteSuccess = $butterCms->deleteCollectionItem($collection->getKey(), $item->getId());
+
+// Legacy - deprecated
+$contentFields = $butterCms->fetchContentFields(['collection_key'], ['locale' => 'en']);
+
 ```
 
 ## Blog Engine
@@ -78,7 +133,7 @@ For a list of `params` see the [API documentation](https://buttercms.com/docs/ap
 ```php
 use ButterCMS\ButterCMS;
 
-$butterCms = new ButterCMS('<auth_token>');
+$butterCms = new ButterCMS('<auth_token>', '<write_auth_token>');
 
 // Posts
 $result = $butterCms->fetchPosts(['page' => 1]);
@@ -101,10 +156,18 @@ foreach ($posts as $post) {
     echo $post->getTitle();
 }
 
+// Create a Post
+$writeApiStatus = $butterCms->createPost($params);
+
 // Query for one post
 $response = $butterCms->fetchPost('post-slug');
 $post = $response->getPost();
 echo $post->getTitle();
+
+// Update a Post
+$postData = json_decode(json_encode($post), true);
+$postData['title'] = 'New Post Title';
+$writeApiStatus = $butterCms->updatePost('post-slug', $postData);
 
 // Authors
 $butterCms->fetchAuthor('author-slug');
@@ -124,7 +187,6 @@ $feed = $butterCms->fetchFeed('rss');
 // Search
 $butterCms->searchPosts('query', ['page' => 1]);
 ```
-
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ require_once('/path/to/buttercms-php/src/ButterCMS.php');
 
 By default the ButterCMS client expects a valid authentication token for all READ operations. For instructions on how to obtain a valid READ authentication token see the [API documentation](https://buttercms.com/docs/api/#authentication).
 
-Optionally, the ButterCMS client accepts a valid authentication token for all WRITE operations. . For instructions on how to obtain a valid WRITE authentication token see the [API documentation](https://buttercms.com/docs/api/#write-authentication).
+Optionally, the ButterCMS client additionally accepts a valid authentication token for all WRITE operations. For instructions on how to obtain a valid WRITE authentication token see the [API documentation](https://buttercms.com/docs/api/#write-authentication).
 
 ```php
 use ButterCMS\ButterCMS;

--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,21 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=8.0",
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "3.*"
+        "squizlabs/php_codesniffer": "3.*",
+        "phpcompatibility/php-compatibility": "10.x-dev"
     },
     "autoload": {
         "psr-0": {
             "ButterCMS": "src/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
         "php": ">=5.3.0",
         "guzzlehttp/guzzle": "^7.0"
     },
+    "require-dev": {
+        "squizlabs/php_codesniffer": "3.*"
+    },
     "autoload": {
         "psr-0": {
             "ButterCMS": "src/"

--- a/src/ButterCMS/ButterCMS.php
+++ b/src/ButterCMS/ButterCMS.php
@@ -2,64 +2,96 @@
 
 namespace ButterCMS;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\BadResponseException;
 use ButterCMS\Model\Author;
 use ButterCMS\Model\Category;
-use ButterCMS\Model\Tag;
+use ButterCMS\Model\CollectionsResponse;
 use ButterCMS\Model\Page;
 use ButterCMS\Model\PagesResponse;
 use ButterCMS\Model\Post;
 use ButterCMS\Model\PostResponse;
 use ButterCMS\Model\PostsResponse;
+use ButterCMS\Model\Tag;
+use ButterCMS\Model\WriteResponse;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
 
 class ButterCMS
 {
-    const
-        VERSION = '2.4.0',
-        API_ROOT_URL = 'https://api.buttercms.com/v2/';
+    protected const VERSION = '2.4.0';
+    protected const API_ROOT_URL = 'https://api.buttercms.com/v2/';
 
-    protected
-        $authToken,
-        $client;
+    protected $maxRetryCount = 1;
+    protected $readAuthToken;
+    protected $readClient;
+    protected $writeAuthToken;
+    protected $writeClient;
 
-    public function __construct($authToken)
+    public function __construct($readAuthToken, $writeAuthToken = null)
     {
-        $this->authToken = $authToken;
+        $defaultClientHeaders = [
+            'X-Butter-Client' => 'PHP/' . self::VERSION,
+            'Accept-Encoding' => 'gzip',
+        ];
 
-        $this->client = new Client([
-            'headers' => [
-                'X-Butter-Client' => 'PHP/' . self::VERSION,
-                'Accept-Encoding' => 'gzip'
-            ],
+        $this->readAuthToken = $readAuthToken;
+        $this->readClient = new Client([
+            'headers' => $defaultClientHeaders,
         ]);
+
+        if ($writeAuthToken) {
+            $this->writeClient = new Client([
+                'headers' => array_merge($defaultClientHeaders, [
+                    'Authorization' => 'Token ' . ($this->writeAuthToken = $writeAuthToken),
+                ]),
+            ]);
+        }
     }
 
-    protected function request($url, $params = [], $tryCount = 0)
+    protected function request(string $method, $url, $query = [], $data = [], $tryCount = 0)
     {
+        $method = strtolower($method);
+
         // Guzzle uses http_build_query() which will convert boolean true to "1"
         // instead of "true" in the GET parameters
-        array_walk($params, function (&$item) {
+        array_walk($query, function (&$item) {
             if (is_bool($item)) {
                 $item = true === $item ? "true" : "false";
             }
         });
 
+        if ($method == 'get') {
+            $query['auth_token'] = $this->readAuthToken;
+            $client = $this->readClient;
+        } else {
+            if (!$client = $this->writeClient) {
+                throw new \BadMethodCallException(
+                    'Write operation attempted without appropriate configuration. ' .
+                    'Did you provide a write-enabled token?'
+                );
+            }
+        }
+
         try {
-            $params['auth_token'] = $this->authToken;
-            $response = $this->client->get(self::API_ROOT_URL . $url, [
-                'query' => $params,
+            $options = array_filter([
+                'query' => $query,
+                'json' => $data,
             ]);
+            $response = $client->$method(self::API_ROOT_URL . $url, $options);
         } catch (BadResponseException $e) {
             $httpCode = (int)$e->getResponse()->getStatusCode();
-            if ($tryCount < 1 && $httpCode !== 404) {
-                return $this->request($url, $params, ++$tryCount);
+            if ($tryCount < $this->maxRetryCount && $httpCode !== 404) {
+                return $this->request($method, $url, $query, $data, ++$tryCount);
             }
 
             throw $e;
         }
 
         $responseString = $response->getBody()->getContents();
+
+        if ($method == 'delete') {
+            return true;
+        }
+
         $dataArray = json_decode($responseString, true);
         if (is_array($dataArray) && JSON_ERROR_NONE === json_last_error()) {
             return $dataArray;
@@ -74,7 +106,7 @@ class ButterCMS
 
     public function fetchFeed($type)
     {
-        $feedData = $this->request('feeds/' . $type . '/');
+        $feedData = $this->request('GET', 'feeds/' . $type . '/');
         return new \SimpleXMLElement($feedData['data']);
     }
 
@@ -84,13 +116,13 @@ class ButterCMS
 
     public function fetchAuthor($authorSlug)
     {
-        $rawAuthor = $this->request('authors/' . $authorSlug . '/');
+        $rawAuthor = $this->request('GET', 'authors/' . $authorSlug . '/');
         return new Author($rawAuthor['data']);
     }
 
     public function fetchAuthors(array $params = [])
     {
-        $rawAuthors = $this->request('authors/', $params);
+        $rawAuthors = $this->request('GET', 'authors/', $params);
         $authors = [];
         foreach ($rawAuthors['data'] as $rawAuthor) {
             $authors[] = new Author($rawAuthor);
@@ -104,13 +136,13 @@ class ButterCMS
 
     public function fetchCategory($categorySlug)
     {
-        $rawCategory = $this->request('categories/' . $categorySlug . '/');
+        $rawCategory = $this->request('GET', 'categories/' . $categorySlug . '/');
         return new Category($rawCategory['data']);
     }
 
     public function fetchCategories(array $params = [])
     {
-        $rawCategories = $this->request('categories/', $params);
+        $rawCategories = $this->request('GET', 'categories/', $params);
         $categories = [];
         foreach ($rawCategories['data'] as $rawCategory) {
             $categories[] = new Category($rawCategory);
@@ -124,13 +156,13 @@ class ButterCMS
 
     public function fetchTag($tagSlug)
     {
-        $rawTag = $this->request('tags/' . $tagSlug . '/');
+        $rawTag = $this->request('GET', 'tags/' . $tagSlug . '/');
         return new Tag($rawTag['data']);
     }
 
     public function fetchTags(array $params = [])
     {
-        $rawTags = $this->request('tags/', $params);
+        $rawTags = $this->request('GET', 'tags/', $params);
         $tags = [];
         foreach ($rawTags['data'] as $rawTag) {
             $tags[] = new Tag($rawTag);
@@ -142,50 +174,117 @@ class ButterCMS
     // Pages
     ///////////////
 
+    public function createPage(array $params = [])
+    {
+        $rawPage = $this->request('POST', 'pages/', [], $params);
+        return new WriteResponse($rawPage);
+    }
+
     public function fetchPage($type, $slug, array $params = [])
     {
-        $rawPage = $this->request('pages/' . $type . '/' . $slug . '/', $params);
+        $rawPage = $this->request('GET', 'pages/' . $type . '/' . $slug . '/', $params);
         return new Page($rawPage['data']);
     }
 
     public function fetchPages($type, array $params = [])
     {
-        $rawPages = $this->request('pages/' . $type . '/', $params);
+        $rawPages = $this->request('GET', 'pages/' . $type . '/', $params);
         return new PagesResponse($rawPages);
+    }
+
+    public function updatePage($slug, array $params = [])
+    {
+        $rawPage = $this->request('PATCH', 'pages/*/' . $slug . '/', [], $params);
+        return new WriteResponse($rawPage);
     }
 
     ///////////////
     // Posts
     ///////////////
 
+    public function createPost(array $params = [])
+    {
+        $rawPost = $this->request('POST', 'posts/', [], $params);
+        return new WriteResponse($rawPost);
+    }
+
     public function fetchPost($postSlug)
     {
-        $rawPost = $this->request('posts/' . $postSlug . '/');
+        $rawPost = $this->request('GET', 'posts/' . $postSlug . '/');
         return new PostResponse($rawPost);
     }
 
     public function fetchPosts(array $params = [])
     {
-        $rawPosts = $this->request('posts/', $params);
+        $rawPosts = $this->request('GET', 'posts/', $params);
         return new PostsResponse($rawPosts);
     }
 
     public function searchPosts($query, array $params = [])
     {
         $params['query'] = $query;
-        $rawPosts = $this->request('search/', $params);
+        $rawPosts = $this->request('GET', 'search/', $params);
         return new PostsResponse($rawPosts);
     }
 
-    ///////////////
-    // Content Fields
-    ///////////////
+    public function updatePost($postSlug, array $params = [])
+    {
+        $rawPost = $this->request('PATCH', 'posts/' . $postSlug . '/', [], $params);
+        return new WriteResponse($rawPost);
+    }
 
-    public function fetchContentFields(array $keys, array $options = [])
+    /////////////////////////////////////////////
+    // Collections (formerly "Content Fields")
+    /////////////////////////////////////////////
+
+    public function createCollectionItem($collectionKey, array $params = [])
+    {
+        $params['key'] = $collectionKey;
+        $rawCollectionItem = $this->request('POST', 'content/', [], $params);
+        return new WriteResponse($rawCollectionItem);
+    }
+
+    public function deleteCollectionItem($collectionKey, $id)
+    {
+        return $this->request('DELETE', 'content/' . $collectionKey . '/' . $id . '/');
+    }
+
+    public function fetchCollections(array $keys = [], array $options = [])
     {
         $params = ['keys' => implode(',', $keys)];
         $params = array_merge($params, $options);
-        $rawContentFields = $this->request('content/', $params);
-        return isset($rawContentFields['data']) ? $rawContentFields['data'] : false;
+        $rawCollections = $this->request('GET', 'content/', $params);
+        return new CollectionsResponse($rawCollections);
+    }
+
+    public function updateCollectionItem($collectionKey, $id, array $params = [])
+    {
+        $rawCollectionItem = $this->request('PATCH', 'content/' . $collectionKey . '/' . $id . '/', [], $params);
+        return new WriteResponse($rawCollectionItem);
+    }
+
+    /**
+     * @deprecated Use fetchCollections instead.
+     */
+    public function fetchContentFields(array $keys, array $options = [])
+    {
+        $response = $this->fetchCollections($keys, $options);
+
+        $legacyDataModel = [];
+
+        foreach ($response->getCollections() as $collection) {
+            $legacyDataModel[$collection->getKey()] = array_map(function ($item) {
+                $itemModel = [];
+                $itemModel['meta']['id'] = $item->getId();
+
+                foreach ($item->getFields() as $key => $value) {
+                    $itemModel[$key] = $value;
+                }
+
+                return $itemModel;
+            }, $collection->getItems());
+        }
+
+        return $legacyDataModel ?: false;
     }
 }

--- a/src/ButterCMS/ButterCMS.php
+++ b/src/ButterCMS/ButterCMS.php
@@ -17,7 +17,7 @@ use GuzzleHttp\Exception\BadResponseException;
 
 class ButterCMS
 {
-    protected const VERSION = '2.4.0';
+    protected const VERSION = '3.0.0';
     protected const API_ROOT_URL = 'https://api.buttercms.com/v2/';
 
     protected $maxRetryCount = 1;

--- a/src/ButterCMS/ButterCMS.php
+++ b/src/ButterCMS/ButterCMS.php
@@ -100,6 +100,30 @@ class ButterCMS
         throw new \UnexpectedValueException('API response was invalid JSON: ' . $responseString);
     }
 
+    public function getReadClient()
+    {
+        return $this->readClient;
+    }
+
+    public function setReadClient(Client $client)
+    {
+        $this->readClient = $client;
+
+        return $this;
+    }
+
+    public function getWriteClient()
+    {
+        return $this->writeClient;
+    }
+
+    public function setWriteClient(Client $client)
+    {
+        $this->writeClient = $client;
+
+        return $this;
+    }
+
     ///////////////
     // Feeds
     ///////////////

--- a/src/ButterCMS/Model/Author.php
+++ b/src/ButterCMS/Model/Author.php
@@ -4,17 +4,16 @@ namespace ButterCMS\Model;
 
 class Author extends Model
 {
-    protected
-        $slug,
-        $first_name,
-        $last_name,
-        $email,
-        $bio,
-        $title,
-        $linkedin_url,
-        $facebook_url,
-        $pinterest_url,
-        $instagram_url,
-        $twitter_handle,
-        $profile_image;
+    protected $slug;
+    protected $first_name;
+    protected $last_name;
+    protected $email;
+    protected $bio;
+    protected $title;
+    protected $linkedin_url;
+    protected $facebook_url;
+    protected $pinterest_url;
+    protected $instagram_url;
+    protected $twitter_handle;
+    protected $profile_image;
 }

--- a/src/ButterCMS/Model/Category.php
+++ b/src/ButterCMS/Model/Category.php
@@ -4,7 +4,6 @@ namespace ButterCMS\Model;
 
 class Category extends Model
 {
-    protected
-        $slug,
-        $name;
+    protected $slug;
+    protected $name;
 }

--- a/src/ButterCMS/Model/Collection.php
+++ b/src/ButterCMS/Model/Collection.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ButterCMS\Model;
+
+class Collection extends Model
+{
+    protected $key;
+    protected $items;
+
+    public function __construct(array $data)
+    {
+        $this->items = [];
+
+        if (!empty($data['items'])) {
+            foreach ($data['items'] as $item) {
+                $this->items[] = new CollectionItem($item);
+            }
+            unset($data['items']);
+        }
+
+        parent::__construct($data);
+    }
+}

--- a/src/ButterCMS/Model/CollectionItem.php
+++ b/src/ButterCMS/Model/CollectionItem.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ButterCMS\Model;
+
+class CollectionItem extends Model
+{
+    protected $id;
+    protected $fields;
+
+    public function __construct(array $data)
+    {
+        if (!empty($data['meta'])) {
+            foreach ($data['meta'] as $key => $value) {
+                if (property_exists($this, $key)) {
+                    $this->$key = $value;
+                }
+            }
+            unset($data['meta']);
+        }
+
+        $this->fields = $data;
+    }
+
+    public function getField($fieldName, $default = null)
+    {
+        return isset($this->fields[$fieldName]) ? $this->fields[$fieldName] : $default;
+    }
+}

--- a/src/ButterCMS/Model/CollectionsResponse.php
+++ b/src/ButterCMS/Model/CollectionsResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ButterCMS\Model;
+
+class CollectionsResponse extends Model
+{
+    protected $collections;
+
+    public function __construct(array $data)
+    {
+        $this->collections = [];
+
+        if (!empty($data['data'])) {
+            foreach ($data['data'] as $collection => $items) {
+                $this->collections[] = new Collection([
+                    'key' => $collection,
+                    'items' => $items,
+                ]);
+            }
+            unset($data['data']);
+        }
+
+        parent::__construct($data);
+    }
+
+    public function getCollection($collectionKey)
+    {
+        return array_values(array_filter($this->collections, function ($collection) use ($collectionKey) {
+            return $collection->getKey() == $collectionKey;
+        }))[0] ?? null;
+    }
+}

--- a/src/ButterCMS/Model/MetaResponse.php
+++ b/src/ButterCMS/Model/MetaResponse.php
@@ -4,6 +4,5 @@ namespace ButterCMS\Model;
 
 class MetaResponse extends Model
 {
-    protected
-        $meta;
+    protected $meta;
 }

--- a/src/ButterCMS/Model/Model.php
+++ b/src/ButterCMS/Model/Model.php
@@ -2,13 +2,14 @@
 
 namespace ButterCMS\Model;
 
-class Model
+use JsonSerializable;
+
+class Model implements JsonSerializable
 {
     public function __construct(array $data)
     {
-        $class = get_class($this);
         foreach ($data as $key => $value) {
-            if (property_exists($class, $key)) {
+            if (property_exists($this, $key)) {
                 $this->$key = $value;
             }
         }
@@ -21,12 +22,16 @@ class Model
             $propertyName = strtolower(preg_replace('/([a-z])([A-Z])/', '$1_$2', $name));
             $propertyName = substr($propertyName, 4);
 
-            $class = get_class($this);
-            if (!property_exists($class, $propertyName)) {
-                throw new \Exception('Method ' . $name . '() does not exist on class ' . $class);
+            if (!property_exists($this, $propertyName)) {
+                throw new \Exception('Method ' . $name . '() does not exist on class ' . get_class($this));
             }
 
             return $this->$propertyName;
         }
+    }
+
+    public function jsonSerialize()
+    {
+        return get_object_vars($this);
     }
 }

--- a/src/ButterCMS/Model/Page.php
+++ b/src/ButterCMS/Model/Page.php
@@ -4,12 +4,11 @@ namespace ButterCMS\Model;
 
 class Page extends Model
 {
-    protected
-        $slug,
-        $page_type,
-        $published,
-        $updated,
-        $fields;
+    protected $slug;
+    protected $page_type;
+    protected $published;
+    protected $updated;
+    protected $fields;
 
     public function getField($fieldName, $default = null)
     {

--- a/src/ButterCMS/Model/PagesResponse.php
+++ b/src/ButterCMS/Model/PagesResponse.php
@@ -4,8 +4,7 @@ namespace ButterCMS\Model;
 
 class PagesResponse extends MetaResponse
 {
-    protected
-        $pages;
+    protected $pages;
 
     public function __construct(array $dataArray)
     {

--- a/src/ButterCMS/Model/Post.php
+++ b/src/ButterCMS/Model/Post.php
@@ -4,22 +4,21 @@ namespace ButterCMS\Model;
 
 class Post extends Model
 {
-    protected
-        $slug,
-        $url,
-        $published,
-        $created,
-        $status,
-        $title,
-        $body,
-        $summary,
-        $seo_title,
-        $meta_description,
-        $author,
-        $categories,
-        $tags,
-        $featured_image,
-        $featured_image_alt;
+    protected $slug;
+    protected $url;
+    protected $published;
+    protected $created;
+    protected $status;
+    protected $title;
+    protected $body;
+    protected $summary;
+    protected $seo_title;
+    protected $meta_description;
+    protected $author;
+    protected $categories;
+    protected $tags;
+    protected $featured_image;
+    protected $featured_image_alt;
 
     public function __construct(array $data)
     {

--- a/src/ButterCMS/Model/PostResponse.php
+++ b/src/ButterCMS/Model/PostResponse.php
@@ -4,8 +4,7 @@ namespace ButterCMS\Model;
 
 class PostResponse extends MetaResponse
 {
-    protected
-        $post;
+    protected $post;
 
     public function __construct(array $dataArray)
     {

--- a/src/ButterCMS/Model/PostsResponse.php
+++ b/src/ButterCMS/Model/PostsResponse.php
@@ -4,8 +4,7 @@ namespace ButterCMS\Model;
 
 class PostsResponse extends MetaResponse
 {
-    protected
-        $posts;
+    protected $posts;
 
     public function __construct(array $dataArray)
     {

--- a/src/ButterCMS/Model/Tag.php
+++ b/src/ButterCMS/Model/Tag.php
@@ -4,7 +4,6 @@ namespace ButterCMS\Model;
 
 class Tag extends Model
 {
-    protected
-        $slug,
-        $name;
+    protected $slug;
+    protected $name;
 }

--- a/src/ButterCMS/Model/WriteResponse.php
+++ b/src/ButterCMS/Model/WriteResponse.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ButterCMS\Model;
+
+class WriteResponse extends Model
+{
+    protected $status;
+}


### PR DESCRIPTION
This PR includes:

- New models for the Collections domain,
- New model for Write API status response (related to async processing),
- First-party support for Write API operations under the Pages, Blog Engine, and Collections domains,
- Getters and setters for the Read and Write Guzzle clients (to aid in debugging),
- Improved code formatting meeting PSR2 and PSR12 standards,
- No expected breaking changes for backwards compatibility,
- Redundant code changes that were proposed in another, now closed PR: https://github.com/ButterCMS/buttercms-php/pull/10.
- Updates minimum PHP version to 8.0

Resolves #9 