### PR TITLE
Add return type hint to ButterCMS\Model\Model::jsonSerialize to suppress deprecation warning

### DIFF
--- a/src/ButterCMS/ButterCMS.php
+++ b/src/ButterCMS/ButterCMS.php
@@ -17,7 +17,7 @@ use GuzzleHttp\Exception\BadResponseException;
 
 class ButterCMS
 {
-    protected const VERSION = '3.0.0';
+    protected const VERSION = '3.0.1';
     protected const API_ROOT_URL = 'https://api.buttercms.com/v2/';
 
     protected $maxRetryCount = 1;

--- a/src/ButterCMS/Model/Model.php
+++ b/src/ButterCMS/Model/Model.php
@@ -30,7 +30,7 @@ class Model implements JsonSerializable
         }
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }


### PR DESCRIPTION
An oversight on my part when working on #11, according to this deprecation warning the newly added jsonSerialize method should explicitly define a `mixed` return type. 

```
Deprecated: Return type of ButterCMS\Model\Model::jsonSerialize() should either be compatible with
JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to 
temporarily suppress the notice in {project}/vendor/buttercms/buttercms-php/src/ButterCMS/Model/Model.php 
on line 33
```

This PR adds this return type and bumps the hard-coded client version number to the next logical and recommended semantic version number.