### PR TITLE
chore: add release and publish actions + docs

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -8,8 +8,13 @@
 # For more information, see https://github.com/marketplace/actions/release-please-action
 
 
-# PHP Packagist works slightly differently then the other two cases (npm and rubygems). In this case, "publishing a # package" means calling a Packagist webhook which causes Packagist to scan the GitHub repo and look for new versions itself (instead of us pushing a new version into the package repository directly).
-# release-please, apart from opening a PR, also creates a GitHub release and a new tag (in this case the Action is triggered by manually merging the PR). The problem here was that Packagist looked for a new version before release-please was done creating the tag and release. That is why there has to be a dependency so that the publish Action would only start after a proper release has been created.
+# PHP Packagist works slightly differently then the other two cases (npm and rubygems). 
+# In this case, "publishing a # package" means calling a Packagist webhook which causes Packagist to scan the GitHub repo 
+# and look for new versions itself (instead of us pushing a new version into the package repository directly).
+# release-please, apart from opening a PR, also creates a GitHub release 
+# and a new tag (in this case the Action is triggered by manually merging the PR). 
+# The problem here was that Packagist looked for a new version before release-please was done creating the tag and release. 
+# That is why there has to be a dependency so that the publish Action would only start after a proper release has been created.
 # Because these two Actions are connected this way, it seemed logical to me to put them in a single workflow.
 # Comment: https://github.com/ButterCMS/buttercms-php/pull/13/files#r1307254666
 on:

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -11,6 +11,7 @@
 # PHP Packagist works slightly differently then the other two cases (npm and rubygems). In this case, "publishing a # package" means calling a Packagist webhook which causes Packagist to scan the GitHub repo and look for new versions itself (instead of us pushing a new version into the package repository directly).
 # release-please, apart from opening a PR, also creates a GitHub release and a new tag (in this case the Action is # triggered by manually merging the PR). The problem here was that Packagist looked for a new version before release-please was done creating the tag and release. That is why there has to be a dependency so that the publish Action would only start after a proper release has been created.
 # Because these two Actions are connected this way, it seemed logical to me to put them in a single workflow.
+# Comment: https://github.com/ButterCMS/buttercms-php/pull/13/files#r1307254666
 on:
   push:
     branches:

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -9,7 +9,7 @@
 
 
 # PHP Packagist works slightly differently then the other two cases (npm and rubygems). 
-# In this case, "publishing a # package" means calling a Packagist webhook which causes Packagist to scan the GitHub repo 
+# In this case, "publishing a package" means calling a Packagist webhook which causes Packagist to scan the GitHub repo 
 # and look for new versions itself (instead of us pushing a new version into the package repository directly).
 # release-please, apart from opening a PR, also creates a GitHub release 
 # and a new tag (in this case the Action is triggered by manually merging the PR). 

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -1,0 +1,46 @@
+# This workflow opens and updates a pull request with a new package version
+# based on code changes. Merging the pull request updates the version in
+# composer.json, updates the changelog and creates release tags.
+
+# This workflow also publishes the package into the Packagist repository after
+# a new version has been released.
+
+# For more information, see https://github.com/marketplace/actions/release-please-action
+
+
+on:
+  push:
+    branches:
+      - master
+  
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: google-github-actions/release-please-action@v3.7.10
+        with:
+          release-type: php
+          package-name: release-please-action
+          pull-request-title-pattern: "chore(release): ${version}"
+          pull-request-header: ":robot: Merge this PR to release a new version"
+
+  publish-package:
+    # after merging the pull request, a release tag first has to be created 
+    # in the release-please job above, before the publish job starts
+    needs: release-please
+    if: contains(github.event.head_commit.message, 'chore(release)') 
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3.5.3
+
+      - uses: hotaruma/packagist-sync@v1.0.1
+        with:
+          packagist-username: ${{ secrets.PACKAGIST_USERNAME }}
+          api-token: ${{ secrets.PACKAGIST_TOKEN }}
+          

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -9,7 +9,7 @@
 
 
 # PHP Packagist works slightly differently then the other two cases (npm and rubygems). In this case, "publishing a # package" means calling a Packagist webhook which causes Packagist to scan the GitHub repo and look for new versions itself (instead of us pushing a new version into the package repository directly).
-# release-please, apart from opening a PR, also creates a GitHub release and a new tag (in this case the Action is # triggered by manually merging the PR). The problem here was that Packagist looked for a new version before release-please was done creating the tag and release. That is why there has to be a dependency so that the publish Action would only start after a proper release has been created.
+# release-please, apart from opening a PR, also creates a GitHub release and a new tag (in this case the Action is triggered by manually merging the PR). The problem here was that Packagist looked for a new version before release-please was done creating the tag and release. That is why there has to be a dependency so that the publish Action would only start after a proper release has been created.
 # Because these two Actions are connected this way, it seemed logical to me to put them in a single workflow.
 # Comment: https://github.com/ButterCMS/buttercms-php/pull/13/files#r1307254666
 on:

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -8,6 +8,9 @@
 # For more information, see https://github.com/marketplace/actions/release-please-action
 
 
+# PHP Packagist works slightly differently then the other two cases (npm and rubygems). In this case, "publishing a # package" means calling a Packagist webhook which causes Packagist to scan the GitHub repo and look for new versions itself (instead of us pushing a new version into the package repository directly).
+# release-please, apart from opening a PR, also creates a GitHub release and a new tag (in this case the Action is # triggered by manually merging the PR). The problem here was that Packagist looked for a new version before release-please was done creating the tag and release. That is why there has to be a dependency so that the publish Action would only start after a proper release has been created.
+# Because these two Actions are connected this way, it seemed logical to me to put them in a single workflow.
 on:
   push:
     branches:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+## Release and publish a new SDK version
+
+This SDK uses the [`release-please` GitHub Action](https://github.com/google-github-actions/release-please-action) to automate preparing new versions for release.
+
+When you are ready to release a new SDK version, make sure that all your code changes have been approved and merged into the `master` branch and that your code is working. The `release-please` tool generates a changelog based on **commit messages; these messages should follow the [Conventional Commits](https://conventionalcommits.org) specification in order for the changelog to reflect all code changes accurately**. Otherwise, you would need to update the changelog manually before each release.
+
+The `release-please` action opens and maintains a GitHub pull request with changes relevant to a new version release. Approve this pull request to release a new version of the SDK.
+
+After the release, the new version is automatically published into the Packagist repository (see the package [here](https://packagist.org/packages/buttercms/buttercms-php)).

--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,6 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
-    }
+    },
+    "version": "3.0.1"
 }


### PR DESCRIPTION
❗ In order for the release tool to work, it is necessary to make sure that the field "Allow GitHub Actions to create and approve pull requests" in Settings > Actions > General is checked :heavy_check_mark:  ❗ 

❗ In order for the Packagist publish tool to work, the Packagist username and API token (`PACKAGIST_USERNAME`, `PACKAGIST_TOKEN`) have to be added to GitHub Secrets.❗ 

After these changes have been aproved and merged into the `master` branch, the automatic release-please pull request will be opened next time when someone adds something releasable with a conventional commit message (i.e. with a prefix `fix:` or `feat:`).